### PR TITLE
Verify bree.js scheduling accuracy

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -101,10 +101,10 @@ The UI is built and served statically by the API server.
 - **Incremental Updates**: Only processes new or updated content to minimize processing time
 
 ### 7. Operational Excellence
-- **Automated Job Scheduling**: Uses Bree.js for reliable job scheduling with configurable intervals:
-  - Provider title processing: Every 1 hour
-  - Main title aggregation: Every 30 minutes (first run 5 minutes after startup)
-  - Cache purging: Every 15 minutes
+- **Automated Job Scheduling**: The in-process `EngineScheduler` uses native timers and the metadata in `web-api/src/jobs.json` to control recurring jobs:
+  - `syncIPTVProviderTitles`: Runs shortly after startup (configurable delay) and then every 6 hours; triggers downstream jobs on completion
+  - `providerTitlesMonitor`: Executes as a post-job hook to process aggregated titles when the sync finishes
+  - `syncLiveTV`: Refreshes channels and EPG data on startup and every 12 hours
 - **Comprehensive Logging**: Detailed logging with configurable log levels (debug, info, error)
 - **Progress Monitoring**: Real-time progress updates for long-running operations
 - **Health Monitoring**: Health check support for containerized deployments

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -25,9 +25,10 @@ Playarr is a comprehensive IPTV Playlist Manager that aggregates content from mu
 - All data stored in MongoDB for efficient querying and scalability
 - Supports provider-specific cleanup rules and ignore patterns
 - Respects provider priority and enabled status
-- Scheduled job processing with Bree.js:
-  - Provider title fetching: Every 1 hour
-  - Main title aggregation: Every 5 minutes
+- Native EngineScheduler orchestrates recurring jobs defined in `web-api/src/jobs.json`:
+  - IPTV provider sync runs on startup (after a short delay) and then every 6 hours
+  - Live TV synchronization runs on startup and then every 12 hours
+  - Post-execution chains (like `providerTitlesMonitor`) trigger automatically after dependent jobs
 
 ## Multi-Provider Support
 
@@ -126,10 +127,10 @@ All client access methods automatically filter content based on user watchlists.
 
 ### Scheduled Jobs
 
-- **Automated Job Scheduling**: Uses Bree.js for reliable job scheduling
-- **Provider Title Fetching**: Every 1 hour
-- **Main Title Aggregation**: Every 5 minutes
-- **Cache Purging**: Every 15 minutes
+- **Automated Job Scheduling**: Handled by the in-process `EngineScheduler`, which reads intervals and delays from `web-api/src/jobs.json`
+- **Provider Title Fetching** (`syncIPTVProviderTitles`): Starts shortly after boot, repeats every 6 hours, and triggers `providerTitlesMonitor` when complete
+- **Provider Titles Monitor** (`providerTitlesMonitor`): Runs as a post-execution chain to process main titles whenever the sync completes
+- **Live TV Synchronization** (`syncLiveTV`): Runs on startup and every 12 hours to refresh channels and guides
 
 ### Update Detection
 

--- a/web-api/src/engineScheduler.js
+++ b/web-api/src/engineScheduler.js
@@ -10,7 +10,7 @@ const jobsConfig = JSON.parse(readFileSync(join(__dirname, 'jobs.json'), 'utf-8'
 
 /**
  * Engine scheduler class for the Playarr Web-API
- * Manages job scheduling using native setInterval (replaces Bree.js)
+ * Manages job scheduling using native setInterval timers
  */
 export class EngineScheduler {
   /**


### PR DESCRIPTION
Update documentation to reflect the current native `EngineScheduler` implementation.

The previous documentation incorrectly stated that `bree.js` was used for job scheduling; this PR updates `docs/FEATURES.md` and `docs/ARCHITECTURE.md` to accurately describe the `EngineScheduler` and its native timer approach, removing all references to `bree.js`. The `EngineScheduler` class comment is also updated for clarity.

---
<a href="https://cursor.com/background-agent?bcId=bc-45c062eb-889d-4a2a-b4d6-d8c8e2430644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-45c062eb-889d-4a2a-b4d6-d8c8e2430644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace Bree.js references with native `EngineScheduler` scheduling details across docs and refine the scheduler class comment.
> 
> - **Docs**:
>   - **Scheduling Architecture**: Replace Bree.js references with native `EngineScheduler` using timers and `web-api/src/jobs.json`.
>     - Detail job behaviors: `syncIPTVProviderTitles` (startup + 6h, triggers `providerTitlesMonitor`), `providerTitlesMonitor` (post-job), `syncLiveTV` (startup + 12h).
>   - Update sections in `docs/ARCHITECTURE.md` and `docs/FEATURES.md` to reflect new scheduling and intervals.
> - **Code**:
>   - Refine comment in `web-api/src/engineScheduler.js` to state it uses native `setInterval` timers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e2d8d588a34fbf1eed82068b21c8719c60540f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->